### PR TITLE
fix: set default fog values to sane values

### DIFF
--- a/UnZENity-Core/CHANGELOG.md
+++ b/UnZENity-Core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.2.5] - 2025-02-09
+
+### Updated
+- Fog values for world.zen.
+
+
 ## [1.2.4] - 2024-11-02
 
 ### Fixed

--- a/UnZENity-Core/Scenes/Worlds/Gothic1/world.zen.unity
+++ b/UnZENity-Core/Scenes/Worlds/Gothic1/world.zen.unity
@@ -18,8 +18,8 @@ RenderSettings:
   m_FogColor: {r: 0, g: 0, b: 0, a: 1}
   m_FogMode: 1
   m_FogDensity: 0.01
-  m_LinearFogStart: 2500
-  m_LinearFogEnd: 5000
+  m_LinearFogStart: 250
+  m_LinearFogEnd: 500
   m_AmbientSkyColor: {r: 0, g: 0, b: 0, a: 1}
   m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}

--- a/UnZENity-Core/package.json
+++ b/UnZENity-Core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unzenity.core.binaries",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "hideInEditor": false,
     "displayName": "UnZENity-Core-binaries",
     "description": "Binaries normally stored inside LFS. For sake of simplicity and cost neutrality, we load them from here.",


### PR DESCRIPTION
Sets sane default values for the fog in world.zen
Makes fog visible in the world